### PR TITLE
Fix swipe only works once: correct position limiting logic

### DIFF
--- a/swipe-back.js
+++ b/swipe-back.js
@@ -111,7 +111,7 @@ function handleWheel(event) {
     position = 150 * postitionScale;
   }
   if (position < -150 * postitionScale) {
-    postitionScale = -150 * postitionScale;
+      position = -150 * postitionScale;
   }
 
   if (position > 0) {


### PR DESCRIPTION
This pull request fixes a typo in the `handleWheel` function in `swipe-back.js` that was causing incorrect assignment when the position was less than a negative threshold.

- Bug fix:
  * Corrected the assignment from `postitionScale` to `position` when clamping the position to its minimum value in the `handleWheel` function in `swipe-back.js`.